### PR TITLE
prototype: use thebelab instead of Thebe

### DIFF
--- a/sage_package/themes/sage/layout.html
+++ b/sage_package/themes/sage/layout.html
@@ -19,7 +19,7 @@
 
 {% block extrahead %}
     <link rel="icon" href="{{ pathto('_static/sageicon.png', 1) }}" type="image/x-icon" />
-    <script src="{{ pathto('_static/thebe.js', 1) }}" type="text/javascript"></script>
+    <script src="https://unpkg.com/thebelab@0.0.5" type="text/javascript"></script>
     <script src="{{ pathto('_static/thebe-sage.js', 1) }}" type="text/javascript"></script>
 {% endblock %}
 


### PR DESCRIPTION
thebelab is an experiment to update Thebe to run on top of the JupyterLab javascript instead of the old notebook js.

loads thebelab from the unpkg.com CDN for now

cc @nthiery